### PR TITLE
Fixed broken README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@ The MiniZinc Examples Archive - v1.0.0
 =================
 
 This repository contains a collection of small MiniZinc 2.0 models demonstrating various language features.
-These examples are referenced by the [Modeling Discrete Optimization](https://www.coursera.org/course/modelingoptimization) MOOC.  The versions of the examples in this repository are maintained to the latest version of MiniZinc and may differ from reference documents.
+These examples are referenced by the [Basic Modeling for Discrete Optimization](https://www.coursera.org/learn/basic-modeling) MOOC.  The versions of the examples in this repository are maintained to the latest version of MiniZinc and may differ from reference documents.
 


### PR DESCRIPTION
Old Coursera `modeling-discrete-optimization` was linked, updated it to the newer `basic-modeling` course URL.